### PR TITLE
Fix off by one error

### DIFF
--- a/ParsingModules/BibliographyParsingModule.py
+++ b/ParsingModules/BibliographyParsingModule.py
@@ -48,7 +48,7 @@ class BibliographyParsingModule(IParsingModule):
     @staticmethod
     def _find_bibliography_start_page_number(certificate: Certificate) -> int:
         bibliography_start = 0
-        for page_number in range(certificate.get_pages_count(), 0, -1):
+        for page_number in range(certificate.get_pages_count(), 1, -1):
             if (BibliographyParsingModule._is_bib_on_page(certificate, page_number)) and not \
                     (BibliographyParsingModule._is_bib_on_page(certificate, page_number - 1)):
                 bibliography_start = page_number


### PR DESCRIPTION
When parsing a bibliography, if the parser finds a bibliography candidate on the 1st page, it tries to access the 0th page. However, the pages are indexed from 1 so an exception is thrown and the program crashes.

The minimal example of a file that causes the crash it the following [bib.txt](https://github.com/xtuzil/PA193_TeamProject/files/6522859/bib.txt).
