### PR TITLE
Fix out of bounds access

### DIFF
--- a/ParsingModules/ToCHelper/TwoColumnParser.py
+++ b/ParsingModules/ToCHelper/TwoColumnParser.py
@@ -152,10 +152,12 @@ class TwoColumnParser:
         if letter.isnumeric():
             next_number_position = position + 1
             # 2 or more digit number
-            while self._content[next_number_position].isnumeric():
+            while next_number_position < len(self._content) and \
+                    self._content[next_number_position].isnumeric():
                 next_number_position += 1
 
-            while not self._content[next_number_position].isnumeric():
+            while next_number_position < len(self._content) and \
+                    not self._content[next_number_position].isnumeric():
                 next_non_number = self._content[next_number_position]
                 if next_non_number == " " or next_non_number == "\n":
                     if self._SIDE == TWO_COL_PARSER_STATE.LEFT:


### PR DESCRIPTION
There are two related issues in the method `_action_space_fill`. The first while loop doesn't check if the index is out of bounds so when a page ends with a number without a new line, it can crash. A similar issue is in the second while loop. This time, if the page ends with a non-numeric character it can cause a crash.

Example of a file that produces the crash:  [toc.txt](https://github.com/xtuzil/PA193_TeamProject/files/6523099/toc.txt).
